### PR TITLE
Fix: improve crash report saving error handling and logging

### DIFF
--- a/core/src/mindustry/net/CrashHandler.java
+++ b/core/src/mindustry/net/CrashHandler.java
@@ -44,7 +44,16 @@ public class CrashHandler{
         try{
             Core.settings.getDataDirectory().child("crashes").child("crash_" + System.currentTimeMillis() + ".txt")
             .writeString(createReport(exception));
-        }catch(Throwable ignored){
+        }catch(Throwable e){
+            // log the failure to save the crash report
+            try {
+                Log.err("Failed to save crash report: " + Strings.getStackTrace(e));
+                // attempt to write to standard error as a last resort
+                System.err.println("CRASH REPORT SAVING FAILED: " + Strings.getStackTrace(e));
+                System.err.println("ORIGINAL EXCEPTION: " + Strings.getStackTrace(exception));
+            } catch(Throwable ignored) {
+                // nothing more we can do
+            }
         }
     }
 


### PR DESCRIPTION
This pull request enhances the crash logging mechanism in the `CrashHandler` class to handle potential failures when saving crash reports. The most significant change is the addition of a fallback logging system to ensure critical error information is not lost.

Enhancements to crash logging:

* [`core/src/mindustry/net/CrashHandler.java`](diffhunk://#diff-fbaa34b1c2e7fb74d6e0f13ed22d09c959e7f1912aca2c3fe69b9330c7a78d66R47-R56): Added a nested `catch` block to handle exceptions that occur while saving crash reports. This includes logging the failure using `Log.err` and writing the error details to standard error as a fallback.If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
