### PR TITLE
Test/unit coverage core

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -405,9 +405,8 @@ project(":tests"){
             exceptionFormat = 'full'
             showStandardStreams = true
         }
-    }
 
-     reports {
+        reports {
             html {
                 destination = file("$buildDir/reports/tests/test")
             }
@@ -415,6 +414,9 @@ project(":tests"){
                 destination = file("$buildDir/test-results/test")
             }
         }
+    }
+
+     
 }
 
 project(":tools"){
@@ -490,3 +492,5 @@ task resolveDependencies{
         }
     }
 }
+
+apply from: 'test.gradle'

--- a/build.gradle
+++ b/build.gradle
@@ -406,6 +406,15 @@ project(":tests"){
             showStandardStreams = true
         }
     }
+
+     reports {
+            html {
+                destination = file("$buildDir/reports/tests/test")
+            }
+            junitXml {
+                destination = file("$buildDir/test-results/test")
+            }
+        }
 }
 
 project(":tools"){

--- a/test.gradle
+++ b/test.gradle
@@ -1,0 +1,9 @@
+apply plugin: "jacoco"
+
+tasks.register('generateTestReports') {
+    group = 'verification'
+    description = 'Cleans, runs tests, and generates coverage reports.'
+
+    // Ensuring the root clean task is correctly referenced
+    dependsOn clean, ':tests:test', ':tests:jacocoTestReport'
+}

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -1,1 +1,37 @@
 sourceSets.test.resources.srcDirs = ["src/test/resources"]
+
+apply plugin: 'jacoco'
+
+jacoco {
+    toolVersion = "0.8.10" 
+}
+
+jacocoTestReport {
+    dependsOn test // Ensure tests are run before generating the report
+    reports {
+        html {
+            required = true
+            destination file("$buildDir/reports/jacoco/html")
+        }
+        xml {
+            required = true
+            destination file("$buildDir/reports/jacoco/xml")
+        }
+    }
+
+    classDirectories.setFrom(
+        files("${project.rootDir}/core/build/classes/java/main")
+    )
+
+    sourceDirectories.setFrom(
+        files("${project.rootDir}/core/src")
+    )
+
+    executionData.setFrom(
+        fileTree(dir: "$buildDir", includes: [
+            "jacoco/test.exec", // Gradle < 7.x
+            "jacoco/test.exec", // Gradle 8.x
+            "jacoco/testUnitTest.exec"
+        ])
+    )
+}


### PR DESCRIPTION
This PR adds the configuration for generating JUnit test reports and JaCoCo code coverage reports.

JUnit Test Reports: Provides detailed test execution results.
JaCoCo Code Coverage Reports: Tracks test coverage for the project.

Changes Made:
Updated build.gradle (root and test folder) for JUnit and JaCoCo integration.
Added test.gradle in the root directory for managing test configurations.

Usage:
Run the following command to generate the reports:
./gradlew generateTestReports
Reports will be available in build/reports/tests (unit tests) and build/reports/jacoco/test (coverage).

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
