### PR TITLE
feature: added SCC Assignment 2 suffix to custom build subtitle

### DIFF
--- a/core/src/mindustry/core/Version.java
+++ b/core/src/mindustry/core/Version.java
@@ -74,7 +74,7 @@ public class Version{
     /** get menu version without colors */
     public static String combined(){
         if(build == -1){
-            return "custom build";
+            return "custom build For SCC Assignment 2";
         }
         return (type.equals("official") ? modifier : type) + " build " + build + (revision == 0 ? "" : "." + revision) + (commitHash.equals("unknown") ? "" : " (" + commitHash + ")");
     }


### PR DESCRIPTION
Summary
This pull request updates the game's custom build subtitle to include the suffix "SCC Assignment 2".

Changes
- Adds the suffix "SCC Assignment 2" to the custom build subtitle for improved clarity.

Impact
- Non-breaking change: This update only affects the UI display; there are no functional impacts.


- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.